### PR TITLE
Updates to support ubuntu xenial

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -39,7 +39,7 @@ class powerdns::backend (
     ensure  => 'file',
     path    => $config_file,
     content => template("${module_name}/config/KEY-VALUE-conf-file.erb"),
-    mode    => '0600',
+    mode    => $powerdns::backend_file_perms,
     owner   => $powerdns::user,
     group   => $powerdns::group,
     notify  => Service[$powerdns::params::service_name],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,9 +63,10 @@ class powerdns (
     user         => $user,
     group        => $group,
   } ->
+
   powerdns::service { $powerdns::params::service_name:
     service_restart    => $service_restart,
     service_status     => $service_status,
-    service_status_cmd => $service_status_cmd,
+    service_status_cmd => $powerdns::params::service_status_cmd,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -76,7 +76,14 @@ class powerdns::params {
   $service_manage     = true
   $service_restart    = true
   $service_status     = true
-  $service_status_cmd = '/usr/bin/pdns_control ping 2>/dev/null 1>/dev/null'
+  case $::lsbdistcodename {
+    'xenial': {
+      $service_status_cmd = '/usr/bin/pdns_control rping 2>/dev/null 1>/dev/null'
+    }
+    default: {
+      $service_status_cmd = '/usr/bin/pdns_control ping 2>/dev/null 1>/dev/null'
+    }
+  }
   $config_include_dir = "${config_file_path}/pdns.d"
   $config_file_backup = true
   $default_config     = {
@@ -109,7 +116,6 @@ class powerdns::params {
   $recursor_service_name       = 'pdns-recursor'
   $recursor_service_restart    = true
   $recursor_service_status     = true
-  $recursor_service_status_cmd = '/usr/bin/rec_control ping 2>/dev/null 1>/dev/null'
   $recursor_default_config     = {
     'allow-from'               => '127.0.0.1',
     'config-dir'               => $recursor_config_file_path,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,6 +36,7 @@ class powerdns::params {
       $recursor_config_file_path = '/etc/pdns-recursor'
       $recursor_user             ='pdns-recursor'
       $recursor_group            ='pdns-recursor'
+      $backend_file_perms        = '0600'
     }
     'Debian', 'Ubuntu': {
       # main application
@@ -61,6 +62,7 @@ class powerdns::params {
       $recursor_config_file_path = '/etc/powerdns'
       $recursor_user             ='pdns'
       $recursor_group            ='pdns'
+      $backend_file_perms        = '0640'
     }
     default: {
       fail("\"${module_name}\" provides no package default value

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "christiangda-powerdns",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "author": "Christian Gonzalez <christiangda@gmail.com>",
   "summary": "PowerDNS provisioner Module",
   "license": "GPL-3.0",

--- a/spec/classes/backend_family_debian_spec.rb
+++ b/spec/classes/backend_family_debian_spec.rb
@@ -46,7 +46,7 @@ describe 'powerdns::backend', type: 'class' do
           is_expected.to create_file("#{config_file}").with(
             'ensure' => 'file',
             'path'   => "#{config_file}",
-            'mode'   => '0600',
+            'mode'   => '0640',
             'owner'  => "#{user}",
             'group'  => "#{group}",
             'backup' => "#{config_file_backup}"


### PR DESCRIPTION
Support for ubuntu xenail requires 2 changes

**Service status command**
Powerdns 4.0.0 (beta and above) the status command is now rping
`$ sudo /usr/bin/pdns_control rping
PONG`

**File Permissions**
By default on Ubuntu, the pdns-server daemon is privilege separated after reading the configuration files, so both the root and pdns users have to be able to read the configuration files for the daemon to start up.

With the PR here and using this in the manifests:

class { '::powerdns':
....
user => 'pdns',
group => 'root',
}
class { '::powerdns::backend':
...
}
this is possible. This is tested only on ubuntu xenial
 👍 1  
